### PR TITLE
docs: add migration info to readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@
     <h2 style='font-family: sans-serif;'> STYLEGUIDE </h2>
 </div>
 
+## This repository is migrating its functionalities to flipper-ui, in order to centralize the repositories and not duplicate dependencies. It will be deleted when all products that use this repository are migrated to use colors through flipper-ui.
+
+```ts
+before the migration:
+import { theme } from 'nginformatica-styleguide'
+
+after the migration:
+import { theme } from 'flipper-ui/theme'
+```
+
 A repository to center and document, initially, the colors of the NGInformatica Apps.
 
 ## :package: `Install` 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nginformatica-styleguide",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A minimalist styleguide in NGInformatica apps",
   "main": "lib/index.js",
   "typings": "./index.d.ts",


### PR DESCRIPTION
We are migrating the styleguide to flipper-ui in order to reduce the duplicated dependencies and to optimize the products.